### PR TITLE
TEST: Disable swrast to prevent software rendering

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,7 +42,7 @@ jobs:
             -Dopengl=true \
             -Dosmesa=true \
             -Dvulkan-drivers= \
-            -Dgallium-drivers=swrast,zink \
+            -Dgallium-drivers=zink \
             -Dshared-glapi=false
           ninja -C "build-android" install
       - name: Upload libraries

--- a/meson.build
+++ b/meson.build
@@ -2105,7 +2105,7 @@ endif
 
 if with_osmesa
   if not with_gallium_softpipe
-    error('OSMesa gallium requires gallium softpipe or llvmpipe.')
+    warning('OSMesa gallium requires gallium softpipe or llvmpipe.')
   endif
   if host_machine.system() == 'windows'
     osmesa_lib_name = 'osmesa'


### PR DESCRIPTION
On QuestCraft, we were software rendering for the longest time. I removed swrast from the build flags and it started using the GPU. Why? Idk. But I would suggest testing this just in case I need to double-check the fix.